### PR TITLE
Respect grid reverse during bypass operations

### DIFF
--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -30,7 +30,7 @@ class Hyper2000(ZendureLegacy):
             return curPower
 
         power = min(0, max(self.maxCharge, power))
-        if (solar := (0 if self.byPass.is_on else self.solarInputPower.asInt)) > 0:
+        if (solar := (0 if (self.byPass.is_on and self.gridReverse.is_on) else self.solarInputPower.asInt)) > 0:
             power = max(power, self.maxSolar + solar)
         self.mqttInvoke({
             "arguments": [

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -215,7 +215,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
             if await d.power_get():
                 cur = d.packInputPower.asInt - d.outputPackPower.asInt + d.solarInputPower.asInt
                 powerActual += cur
-                powerSolar += 0 if d.byPass.is_on else d.solarInputPower.asInt
+                powerSolar += 0 if (d.byPass.is_on and d.gridReverse.is_on) else d.solarInputPower.asInt
                 availEnergy += d.availableKwh.asNumber
                 d.state = DeviceState.ONLINE
             else:
@@ -261,7 +261,7 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
         if solar > 0 and solar >= abs(power):
             _LOGGER.info(f"Power update => {power} with solar only")
             for d in sorted(self.devices, key=lambda d: d.solarInputPower.asInt):
-                if power > 0 and d.state != DeviceState.OFFLINE and not d.byPass.is_on:
+                if power > 0 and d.state != DeviceState.OFFLINE and not (d.byPass.is_on and d.gridReverse.is_on):
                     pwr = min(d.solarInputPower.asInt, power)
                     power -= d.power_discharge(pwr)
             return

--- a/tests/test_power_changed.py
+++ b/tests/test_power_changed.py
@@ -43,12 +43,13 @@ class DummySensor:
 
 
 class DummyDevice:
-    def __init__(self, pack_in, output_pack, solar_in, avail_kwh=0, bypass=False):
+    def __init__(self, pack_in, output_pack, solar_in, avail_kwh=0, bypass=False, grid_reverse=True):
         self.packInputPower = DummyVal(pack_in)
         self.outputPackPower = DummyVal(output_pack)
         self.solarInputPower = DummyVal(solar_in)
         self.availableKwh = DummyVal(avail_kwh)
         self.byPass = DummyByPass(bypass)
+        self.gridReverse = DummyByPass(grid_reverse)
         self.state = DeviceState.OFFLINE
 
     async def power_get(self):


### PR DESCRIPTION
## Summary
- account for gridReverse flag when bypassing solar input in power calculations
- align Hyper2000 solar handling with gridReverse state
- adapt test utilities for new gridReverse logic

## Testing
- `scripts/lint` *(fails: multiple style violations across repository)*
- `ruff check custom_components/zendure_ha/manager.py custom_components/zendure_ha/devices/hyper2000.py tests/test_power_changed.py` *(fails: line length and other style issues)*
- `pytest -q` *(skipped: homeassistant not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb00105e908330b1aa4e7374876196