### PR TITLE
Respect grid reverse and pass mode selects

### DIFF
--- a/custom_components/zendure_ha/devices/hyper2000.py
+++ b/custom_components/zendure_ha/devices/hyper2000.py
@@ -30,7 +30,16 @@ class Hyper2000(ZendureLegacy):
             return curPower
 
         power = min(0, max(self.maxCharge, power))
-        if (solar := (0 if (self.byPass.is_on and self.gridReverse.is_on) else self.solarInputPower.asInt)) > 0:
+        if (
+            solar := (
+                0
+                if (
+                    self.byPass.is_on
+                    and (self.gridReverse.value == 1 or self.passMode.value == 2)
+                )
+                else self.solarInputPower.asInt
+            )
+        ) > 0:
             power = max(power, self.maxSolar + solar)
         self.mqttInvoke({
             "arguments": [

--- a/tests/test_power_changed.py
+++ b/tests/test_power_changed.py
@@ -26,6 +26,11 @@ class DummyByPass:
         self.is_on = is_on
 
 
+class DummySelect:
+    def __init__(self, value=0):
+        self.value = value
+
+
 class DummySensor:
     def __init__(self):
         self.value = None
@@ -43,13 +48,23 @@ class DummySensor:
 
 
 class DummyDevice:
-    def __init__(self, pack_in, output_pack, solar_in, avail_kwh=0, bypass=False, grid_reverse=True):
+    def __init__(
+        self,
+        pack_in,
+        output_pack,
+        solar_in,
+        avail_kwh=0,
+        bypass=False,
+        grid_reverse=1,
+        pass_mode=0,
+    ):
         self.packInputPower = DummyVal(pack_in)
         self.outputPackPower = DummyVal(output_pack)
         self.solarInputPower = DummyVal(solar_in)
         self.availableKwh = DummyVal(avail_kwh)
         self.byPass = DummyByPass(bypass)
-        self.gridReverse = DummyByPass(grid_reverse)
+        self.gridReverse = DummySelect(grid_reverse)
+        self.passMode = DummySelect(pass_mode)
         self.state = DeviceState.OFFLINE
 
     async def power_get(self):


### PR DESCRIPTION
## Summary
- Base device power calculations on `gridReverse` and `passMode` select values instead of binary switch state
- Include `passMode` in bypass checks for Hyper2000 devices
- Update tests to mock select values for `gridReverse` and `passMode`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb037d8dac8330a140db2a3a9c27fe