### PR TITLE
Add logging and asyncio imports

### DIFF
--- a/custom_components/zendure_ha/number.py
+++ b/custom_components/zendure_ha/number.py
@@ -1,7 +1,8 @@
+import logging
+import asyncio
+
 """Interfaces with the Zendure Integration number."""
 
-import asyncio
-import logging
 from collections.abc import Callable
 from typing import Any
 


### PR DESCRIPTION
## Summary
- move logging and asyncio imports to the top of `number.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a54dac083309186d5bde3135587