### PR TITLE
log exceptions

### DIFF
--- a/custom_components/zendure_ha/api.py
+++ b/custom_components/zendure_ha/api.py
@@ -229,7 +229,8 @@ class Api:
             else:
                 _LOGGER.info(f"Unknown device: {deviceId} => {msg.topic} => {msg.payload}")
 
-        except:  # noqa: E722
+        except Exception as err:
+            _LOGGER.error(err)
             return
 
     def mqttMsgLocal(self, client: Any, _userdata: Any, msg: Any) -> None:

--- a/custom_components/zendure_ha/manager.py
+++ b/custom_components/zendure_ha/manager.py
@@ -428,8 +428,13 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
 
                 device.fusegroup = fusegroup
                 self.fuseGroup[device.deviceId] = fusegroup
-            except:  # noqa: E722
-                _LOGGER.error(f"Unable to create fusegroup for device: {device.name} ({device.deviceId})")
+            except Exception as err:
+                _LOGGER.error(
+                    "Unable to create fusegroup for device: %s (%s) - %s",
+                    device.name,
+                    device.deviceId,
+                    err,
+                )
 
         # Update the fusegroups and select optins for each device
         for device in self.devices:
@@ -447,8 +452,13 @@ class ZendureManager(DataUpdateCoordinator[None], EntityDevice):
                     if c.deviceId != device.deviceId:
                         fusegroups[c.deviceId] = f"Part of {c.name} fusegroup"
                 device.fuseGroup.setDict(fusegroups)
-            except:  # noqa: E722
-                _LOGGER.error(f"Unable to create fusegroup for device: {device.name} ({device.deviceId})")
+            except Exception as err:
+                _LOGGER.error(
+                    "Unable to create fusegroup for device: %s (%s) - %s",
+                    device.name,
+                    device.deviceId,
+                    err,
+                )
 
         # Add devices to fusegroups
         for device in self.devices:


### PR DESCRIPTION
## Summary
- replace bare except with logging in API message handler
- log fusegroup creation errors

## Testing
- `ruff check custom_components/zendure_ha/api.py custom_components/zendure_ha/manager.py` *(fails: Found 63 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb4bac24348330b0341d6798c24add